### PR TITLE
Update some IPSec test configs to work with recent head

### DIFF
--- a/IPSEC/Configs/dut-aes-cbc.conf
+++ b/IPSEC/Configs/dut-aes-cbc.conf
@@ -7,7 +7,7 @@ flush;
 spdflush;
 # Host to host ESP
 # Security Associations
-add 172.16.0.1 172.16.0.2 esp 0x10001 -E rijndael-cbc 0xffffffffffffffffffffffffffffffff;
+add 172.16.0.1 172.16.0.2 esp 0x10000 -E rijndael-cbc 0xffffffffffffffffffffffffffffffff;
 add 172.16.0.2 172.16.0.1 esp 0x10001 -E rijndael-cbc 0xffffffffffffffffffffffffffffffff;
 # Security Policies
 spdadd 172.16.0.1 172.16.0.2 any -P in ipsec esp/transport/172.16.0.1-172.16.0.2/require;

--- a/IPSEC/Configs/dut-aes-ctr.conf
+++ b/IPSEC/Configs/dut-aes-ctr.conf
@@ -5,8 +5,8 @@ flush;
 spdflush;
 # Host to host ESP
 # Security Associations
-add 172.16.0.1 172.16.0.2 esp 0x10000 -E aes-ctr 0x3ffe05014819ffff3ffe05014819ffff ;
-add 172.16.0.2 172.16.0.1 esp 0x10001 -E aes-ctr 0x3ffe05014819ffff3ffe05014819ffff ;
+add 172.16.0.1 172.16.0.2 esp 0x10000 -E aes-ctr 0x3ffe05014819ffff3ffe05014819ffff00112233 ;
+add 172.16.0.2 172.16.0.1 esp 0x10001 -E aes-ctr 0x3ffe05014819ffff3ffe05014819ffff00112233 ;
 # Security Policies
 spdadd 172.16.0.1 172.16.0.2 any -P in ipsec esp/tunnel/172.16.0.1-172.16.0.2/require;
 spdadd 172.16.0.2 172.16.0.1 any -P out ipsec esp/tunnel/172.16.0.2-172.16.0.1/require;

--- a/IPSEC/Configs/dut-null.conf
+++ b/IPSEC/Configs/dut-null.conf
@@ -5,7 +5,7 @@ flush;
 spdflush;
 # Host to host ESP
 # Security Associations
-add 172.16.0.1 172.16.0.2 esp 0x10001 -E null 0xffff;
+add 172.16.0.1 172.16.0.2 esp 0x10000 -E null 0xffff;
 add 172.16.0.2 172.16.0.1 esp 0x10001 -E null 0xffff;
 # Security Policies
 spdadd 172.16.0.1 172.16.0.2 any -P in ipsec esp/tunnel/172.16.0.1-172.16.0.2/require;

--- a/IPSEC/Configs/source-aes-cbc.conf
+++ b/IPSEC/Configs/source-aes-cbc.conf
@@ -6,7 +6,7 @@ flush;
 spdflush;
 # Host to host ESP
 # Security Associations
-add 172.16.0.1 172.16.0.2 esp 0x10001 -E rijndael-cbc 0xffffffffffffffffffffffffffffffff; 
+add 172.16.0.1 172.16.0.2 esp 0x10000 -E rijndael-cbc 0xffffffffffffffffffffffffffffffff;
 add 172.16.0.2 172.16.0.1 esp 0x10001 -E rijndael-cbc 0xffffffffffffffffffffffffffffffff;
 # Security Policies
 spdadd 172.16.0.1 172.16.0.2 any -P out ipsec esp/transport/172.16.0.1-172.16.0.2/require;

--- a/IPSEC/Configs/source-aes-ctr.conf
+++ b/IPSEC/Configs/source-aes-ctr.conf
@@ -5,8 +5,8 @@ flush;
 spdflush;
 # Host to host ESP
 # Security Associations
-add 172.16.0.1 172.16.0.2 esp 0x10000 -E aes-ctr 0x3ffe05014819ffff3ffe05014819ffff ;
-add 172.16.0.2 172.16.0.1 esp 0x10001 -E aes-ctr 0x3ffe05014819ffff3ffe05014819ffff ;
+add 172.16.0.1 172.16.0.2 esp 0x10000 -E aes-ctr 0x3ffe05014819ffff3ffe05014819ffff00112233 ;
+add 172.16.0.2 172.16.0.1 esp 0x10001 -E aes-ctr 0x3ffe05014819ffff3ffe05014819ffff00112233 ;
 # Security Policies
 spdadd 172.16.0.1 172.16.0.2 any -P out ipsec esp/tunnel/172.16.0.1-172.16.0.2/require;
 spdadd 172.16.0.2 172.16.0.1 any -P in ipsec esp/tunnel/172.16.0.2-172.16.0.1/require;

--- a/IPSEC/Configs/source-null.conf
+++ b/IPSEC/Configs/source-null.conf
@@ -5,7 +5,7 @@ flush;
 spdflush;
 # Host to host ESP
 # Security Associations
-add 172.16.0.1 172.16.0.2 esp 0x10001 -E null 0xffff;
+add 172.16.0.1 172.16.0.2 esp 0x10000 -E null 0xffff;
 add 172.16.0.2 172.16.0.1 esp 0x10001 -E null 0xffff;
 # Security Policies
 spdadd 172.16.0.1 172.16.0.2 any -P out ipsec esp/tunnel/172.16.0.1-172.16.0.2/require;


### PR DESCRIPTION
12 appears to be pickier about having unique SPI's for each SA than 11.  With 12 I get EEXIST errors from setkey trying to use configs with multiple SAs with the same SPI.  Not sure if this is fallout from ae@'s recent rework of IPSec.

For the AES-CTR tests, AES-CTR requires a 32-bit nonce in addition to the regular key as part of the key set for the SA.