### PR TITLE
Add setkey configurations for AES-CTR with SHA2 512 HMAC.

### DIFF
--- a/IPSEC/Configs/dut-aes-ctr-hmac-sha2-512.conf
+++ b/IPSEC/Configs/dut-aes-ctr-hmac-sha2-512.conf
@@ -1,0 +1,12 @@
+#
+# setkey config for the source of packets/connections
+#
+flush;
+spdflush;
+# Host to host ESP
+# Security Associations
+add 172.16.0.1 172.16.0.2 esp 0x10000 -E aes-ctr 0x3ffe05014819ffff3ffe05014819ffff00112233 -A hmac-sha2-512 "1234567890123456789012345678901234567890123456789012345678901234";
+add 172.16.0.2 172.16.0.1 esp 0x10001 -E aes-ctr 0x3ffe05014819ffff3ffe05014819ffff00112233 -A hmac-sha2-512 "1234567890123456789012345678901234567890123456789012345678901234";
+# Security Policies
+spdadd 172.16.0.1 172.16.0.2 any -P in ipsec esp/tunnel/172.16.0.1-172.16.0.2/require;
+spdadd 172.16.0.2 172.16.0.1 any -P out ipsec esp/tunnel/172.16.0.2-172.16.0.1/require;

--- a/IPSEC/Configs/source-aes-ctr-hmac-sha2-512.conf
+++ b/IPSEC/Configs/source-aes-ctr-hmac-sha2-512.conf
@@ -1,0 +1,12 @@
+#
+# setkey config for the source of packets/connections
+#
+flush;
+spdflush;
+# Host to host ESP
+# Security Associations
+add 172.16.0.1 172.16.0.2 esp 0x10000 -E aes-ctr 0x3ffe05014819ffff3ffe05014819ffff00112233 -A hmac-sha2-512 "1234567890123456789012345678901234567890123456789012345678901234";
+add 172.16.0.2 172.16.0.1 esp 0x10001 -E aes-ctr 0x3ffe05014819ffff3ffe05014819ffff00112233 -A hmac-sha2-512 "1234567890123456789012345678901234567890123456789012345678901234";
+# Security Policies
+spdadd 172.16.0.1 172.16.0.2 any -P out ipsec esp/tunnel/172.16.0.1-172.16.0.2/require;
+spdadd 172.16.0.2 172.16.0.1 any -P in ipsec esp/tunnel/172.16.0.2-172.16.0.1/require;


### PR DESCRIPTION
The draft-ietf-ipsec-ciph-aes-ctr-05 (which is newer than -03 mentioned in the setkey manpage) includes this note at the end of page 3:

>    With AES-CTR, it is trivial to use a valid ciphertext to forge other
>    (valid to the decryptor) ciphertexts.  Thus, it is equally
>    catastrophic to use AES-CTR without a companion authentication
>    function.  Implementations MUST use AES-CTR in conjunction with an
>    authentication function, such as HMAC-SHA-1-96 [HMAC-SHA].

Thus, it makes sense to include a test that combines AES-CTR with an HMAC.  In this case I chose SHA2 512 as the existing tests for AES-CBC used SHA1 and SHA2 256.